### PR TITLE
Update README and RELEASING

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ If you want to use just the Java client, the Maven dependency is:
 </dependency>
 ````
 
-Until the artifacts are released to Maven Central, please use our public repo:
-`http://public-repo.ci.cloud.commercetools.de/content/repositories/releases`
+These artifacts are deployed to Maven Central.
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,5 +26,4 @@ generated with the appropriate version number.
 
 ###TODO
 
-* The version bump task sadly doesn't run _during_ the release
 * `sbt release` only calls the `publish` task but should `publish-signed` instead


### PR DESCRIPTION
I took the liberty to update the documentation a little bit.
1. The artifacts are now on Maven Central so there is no need to recommend the internal repository
2. @schleichardt has automated the release process considerably so some TODOs in RELEASING has been removed
