### PR TITLE
Add reference.conf for Play SDK, so the users do not need to explicitly ...

### DIFF
--- a/play-sdk/conf/reference.conf
+++ b/play-sdk/conf/reference.conf
@@ -1,0 +1,2 @@
+sphere.core="https://api.sphere.io"
+sphere.auth="https://auth.sphere.io"


### PR DESCRIPTION
...set the current values for the configuration keys

"sphere.core" and "sphere.auth".

Or do we need this directly for the Java client?
